### PR TITLE
Fix GitHub Pages deployment baseURL issue

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -48,8 +48,7 @@ jobs:
         run: |
           hugo \
             --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"          
+            --minify          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was overriding the baseURL from hugo.toml with the GitHub Pages URL (https://jur1st.github.io/antisocial-fiverings-photo/), but the site is actually served from the custom domain antisocial.fiverings.photo.

This was causing all asset URLs to be generated incorrectly, leading to the site working locally but not on GitHub Pages.

## Solution
- Removed the baseURL override from the GitHub Actions workflow
- The workflow now uses the baseURL from hugo.toml which is correctly set to https://antisocial.fiverings.photo/
- CNAME file is already in place in the static directory
- All URLs are now generated correctly with HTTPS protocol

## Testing
- Built locally and verified all CSS URLs are generated with https://antisocial.fiverings.photo/
- Site works correctly with all themes when served locally

Once merged, the site should work correctly on the custom domain.