### PR TITLE
Fix: SSL certificate errors on fiverings.photo

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+fiverings.photo

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,98 @@
+# Phase 1 SSL Fix - Decision Documentation
+
+**Date**: 2025-08-16  
+**Phase**: 1 - SSL Infrastructure  
+**Author**: GPS Chief of Staff coordinating Infrastructure Agent  
+
+## Decision: HTML Meta Refresh Redirect
+
+### Why This Approach
+
+**Selected**: Simple HTML meta refresh with 0-second delay
+
+**Rationale**:
+1. **Simplicity**: Single HTML file, no build process
+2. **Reliability**: Works on all browsers, no JavaScript required
+3. **GitHub Pages Compatible**: Native support, no configuration needed
+4. **Fast Implementation**: Can deploy immediately
+5. **SEO Friendly**: Includes canonical link tag
+
+### Alternatives Considered
+
+1. **JavaScript Redirect**
+   - Pro: More control over redirect behavior
+   - Con: Requires JavaScript enabled
+   - Con: Slightly slower than meta refresh
+   - **Rejected**: Unnecessary complexity
+
+2. **GitHub Pages 404.html**
+   - Pro: Could handle all paths
+   - Con: Returns 404 status code
+   - Con: Poor for SEO
+   - **Rejected**: Improper status code
+
+3. **Jekyll _config.yml Redirect**
+   - Pro: GitHub's recommended approach
+   - Con: Requires Jekyll build
+   - Con: More complex setup
+   - **Rejected**: Over-engineering for simple redirect
+
+## Decision: Minimal Styling
+
+### Why This Approach
+
+**Selected**: Dark theme with Nikon yellow accent
+
+**Rationale**:
+1. **Brand Consistency**: Matches antisocial.fiverings.photo aesthetic
+2. **Professional**: Clean, minimal appearance during brief display
+3. **Accessible**: High contrast for readability
+4. **Lightweight**: Inline CSS, no external resources
+
+## Decision: CNAME Configuration
+
+### Why This Approach
+
+**Selected**: Simple CNAME file with domain only
+
+**Rationale**:
+1. **GitHub Standard**: Expected by GitHub Pages
+2. **Clean**: No subdomain complexity
+3. **Direct**: Points exactly where needed
+
+## Trust Boundaries Identified
+
+1. **DNS Propagation**: Up to 24-48 hours
+2. **SSL Provisioning**: Automatic but can take time
+3. **Browser Caching**: Users may need to clear cache
+4. **Cross-browser Testing**: Must verify all major browsers
+
+## Future Migration Path
+
+When ready for full site deployment:
+
+1. **Preserve SSL**: Keep CNAME file
+2. **Replace index.html**: With full Hugo build
+3. **No DNS Changes**: Already configured correctly
+4. **Gradual Rollout**: Can test on branch first
+
+## Risk Mitigation
+
+1. **Backup Plan**: Can revert to redirect quickly
+2. **Testing Branch**: Using fix/ssl-placeholder before main
+3. **Documentation**: Everything recorded for future reference
+4. **Simple Rollback**: Just git revert if issues
+
+## Success Criteria
+
+✅ Achievable within 48 hours  
+✅ Zero maintenance required  
+✅ Professional appearance  
+✅ Preserves user trust  
+✅ Enables future development  
+
+---
+
+**Decision Status**: Implemented - awaiting validation  
+**Confidence Level**: High  
+**Technical Debt**: None introduced

--- a/DOMAIN-ARCHITECTURE.md
+++ b/DOMAIN-ARCHITECTURE.md
@@ -1,0 +1,117 @@
+# Domain Architecture - Five Rings Photography
+
+**Date**: 2025-08-16  
+**Purpose**: Document SSL fix and domain configuration  
+
+## Domain Structure
+
+### Primary Domain
+- **Domain**: fiverings.photo
+- **Purpose**: Main brand domain
+- **Current State**: Placeholder with redirect
+- **Hosting**: GitHub Pages
+
+### Subdomain
+- **Domain**: antisocial.fiverings.photo
+- **Purpose**: Active photography gallery
+- **Current State**: Fully operational
+- **Platform**: Hugo static site
+
+## SSL Configuration
+
+### Certificate Provider
+- **Provider**: GitHub Pages (Let's Encrypt)
+- **Type**: Automatic SSL/TLS
+- **Renewal**: Automatic via GitHub Pages
+- **Verification**: HTTP-01 challenge
+
+### DNS Configuration Required
+For fiverings.photo to work with GitHub Pages SSL:
+
+1. **A Records** (point to GitHub Pages servers):
+   - 185.199.108.153
+   - 185.199.109.153
+   - 185.199.110.153
+   - 185.199.111.153
+
+2. **CNAME Record** (if using www):
+   - www.fiverings.photo → jur1st.github.io
+
+## Redirect Implementation
+
+### Method
+HTML meta refresh (0 second delay)
+
+### Rationale
+- Simple and reliable
+- No JavaScript required
+- Works with GitHub Pages
+- Maintains SEO value via canonical link
+
+### Code
+```html
+<meta http-equiv="refresh" content="0; url=https://antisocial.fiverings.photo">
+<link rel="canonical" href="https://antisocial.fiverings.photo">
+```
+
+## GitHub Pages Configuration
+
+### Repository Settings
+1. Navigate to Settings → Pages
+2. Source: Deploy from branch
+3. Branch: `fix/ssl-placeholder` (temporarily) then `main`
+4. Folder: / (root)
+5. Custom domain: fiverings.photo
+6. Enforce HTTPS: ✓ Enabled
+
+### File Structure
+```
+/
+├── index.html    # Redirect placeholder
+├── CNAME         # Domain configuration
+└── DOMAIN-ARCHITECTURE.md  # This documentation
+```
+
+## Deployment Process
+
+1. **Create Branch**: `fix/ssl-placeholder`
+2. **Add Files**: index.html, CNAME
+3. **Push to GitHub**: Triggers GitHub Pages build
+4. **DNS Propagation**: May take up to 24 hours
+5. **SSL Provisioning**: Automatic after DNS verified
+6. **Merge to Main**: After validation
+
+## Testing Checklist
+
+- [ ] fiverings.photo loads without SSL warnings
+- [ ] Automatic redirect to antisocial.fiverings.photo
+- [ ] Mobile responsive placeholder
+- [ ] All major browsers tested
+- [ ] DNS properly configured
+- [ ] SSL certificate valid
+
+## Future Considerations
+
+When ready to deploy full site to fiverings.photo:
+1. Remove redirect from index.html
+2. Deploy full Hugo build
+3. Update DNS if needed
+4. Maintain SSL continuity
+
+## Troubleshooting
+
+### SSL Certificate Errors
+- Verify DNS A records
+- Check CNAME file exists
+- Wait for DNS propagation
+- Confirm GitHub Pages settings
+
+### Redirect Not Working
+- Clear browser cache
+- Check meta refresh syntax
+- Verify target URL
+
+---
+
+**Status**: Implementation finished - awaiting validation  
+**Next Step**: Push to GitHub and monitor SSL provisioning

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://antisocial.fiverings.photo">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Five Rings Creative</title>
+    <link rel="canonical" href="https://antisocial.fiverings.photo">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background: #1a1a1a;
+            color: #f0f0f0;
+        }
+        a {
+            color: #FFD700;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <p>Redirecting to <a href="https://antisocial.fiverings.photo">Five Rings Creative Gallery</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Problem
SSL certificate errors on main domain preventing professional presentation

## Solution  
Simple redirect placeholder via GitHub Pages with:
- HTML meta refresh (0 second delay)
- CNAME configuration for custom domain
- Dark theme matching brand aesthetic
- Comprehensive documentation

## Testing Required
Please verify after DNS propagation:
- ✅ fiverings.photo loads without SSL warnings
- ✅ Automatic redirect to antisocial.fiverings.photo
- ✅ Works in Chrome, Firefox, Safari
- ✅ Mobile responsive

## Documentation
- DOMAIN-ARCHITECTURE.md - Complete DNS and SSL configuration
- DECISIONS.md - Rationale for approach taken

## Trust Standards
Implementation finished - awaiting your validation before proceeding to Phase 2

## Next Steps
After validation:
1. 24-hour pause period (Validation Gate 1)
2. Begin Phase 2: Content Strategy

---
GPS-20250816-001 Phase 1 of 7